### PR TITLE
standardize on underscore as delimiter

### DIFF
--- a/packages/service-metrics/package.json
+++ b/packages/service-metrics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ceramicnetwork/observability",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Typescript library for instrumenting ceramic networks",
   "author": "Golda Velez <golda@3box.io>",
   "license": "(Apache-2.0 OR MIT)",

--- a/packages/service-metrics/src/service-metrics.ts
+++ b/packages/service-metrics/src/service-metrics.ts
@@ -228,7 +228,7 @@ class _ServiceMetrics {
     // Create this counter if we have not already
     if (!(name in this.counters)) {
       const full_name = this.append_total_to_counters ?
-        `${this.caller}:${name}_total` : `${this.caller}:${name}`
+        `${this.caller}_${name}_total` : `${this.caller}_${name}`
       this.counters[name] = this.meter.createCounter(full_name)
     }
     // Add to the count


### PR DESCRIPTION
prometheus was converting ':' to '_' , actually use '_' for continuity

all of our metrics are of the form caller_metric_name

but they were sent as caller:metric_name

Prometheus had been converting them to the form with underscores, but after an upgrade they are no longer being converted