### PR TITLE
Parameters for Export and Timeout intervals

### DIFF
--- a/packages/service-metrics/package.json
+++ b/packages/service-metrics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ceramicnetwork/observability",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Typescript library for instrumenting ceramic networks",
   "author": "Golda Velez <golda@3box.io>",
   "license": "(Apache-2.0 OR MIT)",

--- a/packages/service-metrics/src/service-metrics.ts
+++ b/packages/service-metrics/src/service-metrics.ts
@@ -26,6 +26,8 @@ export const UNKNOWN_CALLER = 'Unknown'
 export const CONCURRENCY_LIMIT = 1
 export const TRACE_CONCURRENCY_LIMIT = 1
 export const DEFAULT_TRACE_SAMPLE_RATIO = 0.1
+export const DEFAULT_EXPORT_INTERVAL_MS = 60000 // one minute, is otlp default
+export const DEFAULT_EXPORT_TIMEOUT_MS = 30000  // 30 sec timeout, the otlp default
 
 interface Endable {
   end(endTime?: TimeInput): void;
@@ -137,7 +139,9 @@ class _ServiceMetrics {
     sample_ratio: number = DEFAULT_TRACE_SAMPLE_RATIO,
     logger: any = null,
     append_total_to_counters: boolean = true,
-    prometheusExportPort: number = 0
+    prometheusExportPort: number = 0,
+    exportIntervalMillis: number = DEFAULT_EXPORT_INTERVAL_MS,
+    exportTimeoutMillis: number = DEFAULT_EXPORT_TIMEOUT_MS
   ) {
     this.caller = caller
     const meterProvider = new MeterProvider({
@@ -166,7 +170,8 @@ class _ServiceMetrics {
       meterProvider.addMetricReader(
         new PeriodicExportingMetricReader({
           exporter: metricExporter,
-          exportIntervalMillis: 1000,
+          exportIntervalMillis: exportIntervalMillis,
+          exportTimeoutMillis: exportTimeoutMillis
         })
       )
 


### PR DESCRIPTION
# adjust timeouts - #PLAT-1545 

We are seeing an issue where the metrics disappear shortly after restarting the node.  This might be because the 1 second interval is too short to export all the metrics.

This solution parameterizes the interval and timeout, while setting explicitly to the same defaults as OTLP does - 1 min and 30 sec
