### PR TITLE
add the ability to auto-add labels per instance to differentiate them

### DIFF
--- a/packages/service-metrics/package.json
+++ b/packages/service-metrics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ceramicnetwork/observability",
-  "version": "1.4.7",
+  "version": "1.5.0",
   "description": "Typescript library for instrumenting ceramic networks",
   "author": "Golda Velez <golda@3box.io>",
   "license": "(Apache-2.0 OR MIT)",


### PR DESCRIPTION
We wish to combine counts from 6 or more api instances 

so a single metric name, but different labels

enable setting an instance identifier and automatically adding it to each metric count or observation