### PR TITLE
feat: Expose the NodeMetrics StreamID

### DIFF
--- a/packages/node-metrics/src/constants.ts
+++ b/packages/node-metrics/src/constants.ts
@@ -1,0 +1,16 @@
+import { Networks } from "@ceramicnetwork/common";
+import { StreamID } from "@ceramicnetwork/streamid";
+
+export const NETWORK_MODEL_MAP: Record<Networks, StreamID> = {
+    [Networks.MAINNET]: StreamID.fromString(
+        "kjzl6hvfrbw6cb9pd0bl7zmm28h3qszh56ccpn50vsmrl7clroy4fvln00z7q6q",
+    ),
+    [Networks.TESTNET_CLAY]: StreamID.fromString(
+        "kjzl6hvfrbw6cb9pd0bl7zmm28h3qszh56ccpn50vsmrl7clroy4fvln00z7q6q",
+    ),
+    [Networks.DEV_UNSTABLE]: StreamID.fromString(
+        "kjzl6hvfrbw6cb9pd0bl7zmm28h3qszh56ccpn50vsmrl7clroy4fvln00z7q6q",
+    ),
+    [Networks.LOCAL]: null,
+    [Networks.INMEMORY]: null,
+};

--- a/packages/node-metrics/src/node-metrics.ts
+++ b/packages/node-metrics/src/node-metrics.ts
@@ -1,11 +1,13 @@
 /* Model metrics accumulate and publish on a timer to ceramic */
 
-import type { CeramicApi } from "@ceramicnetwork/common";
+import type { CeramicApi, Networks } from "@ceramicnetwork/common";
 import {
   MetricPublisher,
   CeramicNode,
   PeriodicMetricEventV1,
 } from "./publishMetrics.js";
+import { StreamID } from "@ceramicnetwork/streamid";
+import { NETWORK_MODEL_MAP } from "./constants.js";
 
 export const DEFAULT_PUBLISH_INTERVAL_MS = 60000; // one minute
 
@@ -72,6 +74,14 @@ class _NodeMetrics {
       _NodeMetrics.instance = new _NodeMetrics();
     }
     return _NodeMetrics.instance;
+  }
+
+  /**
+   * Returns the StreamID of the data Model used to publish metrics for the given Ceramic network.
+   * @param network
+   */
+  public getModel(network: Networks): StreamID {
+    return NETWORK_MODEL_MAP[network]
   }
 
   /* ensure the fields are valid for our CeramicNode type */

--- a/packages/node-metrics/src/publishMetrics.ts
+++ b/packages/node-metrics/src/publishMetrics.ts
@@ -2,6 +2,7 @@ import type { CeramicApi } from "@ceramicnetwork/common";
 import { Networks } from "@ceramicnetwork/common";
 import { StreamID } from "@ceramicnetwork/streamid";
 import { ModelInstanceDocument } from "@ceramicnetwork/stream-model-instance";
+import { NETWORK_MODEL_MAP } from "./constants.js";
 
 export interface CeramicNode {
   id: string;
@@ -36,25 +37,11 @@ export class MetricPublisher {
   private ceramic: CeramicApi;
   private modelId: StreamID;
 
-  private static readonly NETWORK_MODEL_MAP: Record<Networks, StreamID> = {
-    [Networks.MAINNET]: StreamID.fromString(
-      "kjzl6hvfrbw6cb9pd0bl7zmm28h3qszh56ccpn50vsmrl7clroy4fvln00z7q6q",
-    ),
-    [Networks.TESTNET_CLAY]: StreamID.fromString(
-      "kjzl6hvfrbw6cb9pd0bl7zmm28h3qszh56ccpn50vsmrl7clroy4fvln00z7q6q",
-    ),
-    [Networks.DEV_UNSTABLE]: StreamID.fromString(
-      "kjzl6hvfrbw6cb9pd0bl7zmm28h3qszh56ccpn50vsmrl7clroy4fvln00z7q6q",
-    ),
-    [Networks.LOCAL]: null,
-    [Networks.INMEMORY]: null,
-  };
-
   // Throws an error if network does not have an associated metric model
   constructor(ceramic: CeramicApi, network: string) {
     this.ceramic = ceramic;
     const networkEnum = network as Networks;
-    this.modelId = MetricPublisher.NETWORK_MODEL_MAP[networkEnum];
+    this.modelId = NETWORK_MODEL_MAP[networkEnum];
     if (!this.modelId) {
       throw new Error(`No metric model available for network ${network}`);
     }


### PR DESCRIPTION
Pre-req for https://linear.app/3boxlabs/issue/AES-206/re-enable-nodemetrics-by-default

js-ceramic needs to subscribe ceramic-one/recon to the NodeMetrics model, and to do that it needs to know the right StreamID to use.