### PR TITLE
Reset the mean and max of timeable metrics after publishing

### DIFF
--- a/packages/service-metrics/package.json
+++ b/packages/service-metrics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ceramicnetwork/observability",
-  "version": "1.5.6",
+  "version": "1.5.7",
   "description": "Typescript library for instrumenting ceramic networks",
   "author": "Golda Velez <golda@3box.io>",
   "license": "(Apache-2.0 OR MIT)",

--- a/packages/service-metrics/src/service-metrics.ts
+++ b/packages/service-metrics/src/service-metrics.ts
@@ -71,6 +71,13 @@ export class TimeableMetric {
     }
   }
 
+  public reset() {
+    this.cnt = 0
+    this.totTime = 0
+    this.maxTime = 0
+  }
+
+
   public recordAll(tasks: Timeable[]) {
     for (const task of tasks) {
       this.record(task)
@@ -101,7 +108,8 @@ export class TimeableMetric {
   /**
   * Publishes the accumulated statistics.
   * This method can be invoked manually or automatically at set intervals.
-  * It publishes the total count, mean time, and maximum time for the given metric.
+  * It publishes the total count, mean time, and maximum time for the given metric,
+  * over the period since the last publish.
   *
   * @param {string} name - The name of the metric to publish statistics for.
   */
@@ -112,6 +120,7 @@ export class TimeableMetric {
     ServiceMetrics.count(name + '_total', this.cnt)
     ServiceMetrics.observe(name + '_mean', this.getMeanTime())
     ServiceMetrics.observe(name + '_max', this.maxTime)
+    this.reset()
   }
 
   startPublishingStats(): void {


### PR DESCRIPTION
An ongoing mean or max over all time is not "mean"ingful. 

We are more interested in the mean and max over the publish intervals.